### PR TITLE
Fix remaining audit bugs — defaults, endpoints, dead code

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tiptap-collaboration-mcp",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "main": "build/index.js",
   "type": "module",
   "scripts": {

--- a/src/server.ts
+++ b/src/server.ts
@@ -16,7 +16,7 @@ let BASE_URL: string | undefined;
 
 const server = new McpServer({
   name: 'tiptap-collaboration-mcp',
-  version: '1.1.0',
+  version: '1.1.1',
   capabilities: {
     resources: {},
     tools: {},

--- a/src/tools/create-document.ts
+++ b/src/tools/create-document.ts
@@ -17,21 +17,7 @@ export default function registerCreateDocument(
         .passthrough()
         .default({
           type: 'doc',
-          content: [
-            {
-              type: 'paragraph',
-              attrs: {
-                indent: 0,
-                textAlign: 'left',
-              },
-              content: [
-                {
-                  text: 'Test',
-                  type: 'text',
-                },
-              ],
-            },
-          ],
+          content: [{ type: 'paragraph' }],
         })
         .describe(
           'Document content in Tiptap JSON format (uses default if not provided)'

--- a/src/tools/duplicate-document.ts
+++ b/src/tools/duplicate-document.ts
@@ -37,11 +37,11 @@ export default function registerDuplicateDocument(
         const sourceContent = await getResponse.json();
 
         const createResponse = await fetch(
-          `${getBaseUrl()}/api/documents?format=json`,
+          `${getBaseUrl()}/api/documents/${targetId}?format=json`,
           {
             method: 'POST',
             headers: buildJsonHeaders(getToken()),
-            body: JSON.stringify({ ...sourceContent, id: targetId }),
+            body: JSON.stringify(sourceContent),
           }
         );
 

--- a/src/tools/export-markdown.ts
+++ b/src/tools/export-markdown.ts
@@ -26,13 +26,13 @@ export default function registerExportMarkdown(
     },
     async ({ content, format = 'md', appId }) => {
       try {
+        // Conversion API uses Bearer token (different from collaboration API which uses raw token)
+        const token = getToken();
         const headers: Record<string, string> = {
           'User-Agent': 'tiptap-collaboration-mcp',
           'Content-Type': 'application/json',
           'X-App-Id': appId,
         };
-
-        const token = getToken();
         if (token) headers['Authorization'] = `Bearer ${token}`;
 
         const response = await fetch(`${getBaseUrl()}/api/convert/export`, {

--- a/src/tools/import-markdown.ts
+++ b/src/tools/import-markdown.ts
@@ -1,6 +1,6 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
-import { mcpError, mcpSuccess } from '../utils/mcp-helpers.js';
+import { buildHeaders, mcpError, mcpSuccess } from '../utils/mcp-helpers.js';
 
 export default function registerImportMarkdown(
   server: McpServer,
@@ -26,13 +26,12 @@ export default function registerImportMarkdown(
     },
     async ({ content, format = 'md', appId }) => {
       try {
-        const headers: Record<string, string> = {
-          'User-Agent': 'tiptap-collaboration-mcp',
-          'X-App-Id': appId,
-        };
-
+        // Conversion API uses Bearer token (different from collaboration API which uses raw token)
         const token = getToken();
-        if (token) headers['Authorization'] = `Bearer ${token}`;
+        const headers = buildHeaders(
+          token ? `Bearer ${token}` : undefined,
+          { 'X-App-Id': appId }
+        );
 
         const formData = new FormData();
         const blob = new Blob([content], { type: 'text/markdown' });

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -133,10 +133,10 @@ describe('MCP Server Integration Tests', () => {
     });
 
     it('should register tools with proper handler functions', () => {
-      registerGetServerStatistics(server, getBaseUrl, getToken);
+      registerListDocuments(server, getBaseUrl, getToken);
 
       const call = (server.tool as any).mock.calls.find(
-        (call: any) => call[0] === 'get-server-statistics'
+        (call: any) => call[0] === 'list-documents'
       );
 
       expect(call).toBeDefined();
@@ -149,7 +149,7 @@ describe('MCP Server Integration Tests', () => {
       const invalidGetBaseUrl = () => '';
 
       expect(() => {
-        registerGetServerStatistics(server, invalidGetBaseUrl, getToken);
+        registerDeleteDocument(server, invalidGetBaseUrl, getToken);
       }).not.toThrow();
     });
 
@@ -166,12 +166,12 @@ describe('MCP Server Integration Tests', () => {
       const invalidGetToken = () => 'invalid-token';
 
       expect(() => {
-        registerGetServerStatistics(server, invalidGetBaseUrl, invalidGetToken);
-        registerListDocuments(server, invalidGetBaseUrl, invalidGetToken);
+        registerDuplicateDocument(server, invalidGetBaseUrl, invalidGetToken);
+        registerSearchDocuments(server, invalidGetBaseUrl, invalidGetToken);
       }).not.toThrow();
 
-      expect(registeredTools).toContain('get-server-statistics');
-      expect(registeredTools).toContain('list-documents');
+      expect(registeredTools).toContain('duplicate-document');
+      expect(registeredTools).toContain('search-documents');
     });
   });
 
@@ -215,7 +215,7 @@ describe('MCP Server Integration Tests', () => {
       const customBaseUrl = 'https://custom-server.example.com:9000';
       const customGetBaseUrl = vi.fn(() => customBaseUrl);
 
-      registerGetServerStatistics(server, customGetBaseUrl, getToken);
+      registerGetDocumentStatistics(server, customGetBaseUrl, getToken);
 
       expect(customGetBaseUrl).toBeDefined();
     });
@@ -234,12 +234,12 @@ describe('MCP Server Integration Tests', () => {
       const envGetToken = () => process.env.TOKEN;
 
       expect(() => {
-        registerGetServerStatistics(server, envGetBaseUrl, envGetToken);
-        registerListDocuments(server, envGetBaseUrl, envGetToken);
+        registerUpdateDocument(server, envGetBaseUrl, envGetToken);
+        registerImportMarkdown(server, envGetBaseUrl, envGetToken);
       }).not.toThrow();
 
-      expect(registeredTools).toContain('get-server-statistics');
-      expect(registeredTools).toContain('list-documents');
+      expect(registeredTools).toContain('update-document');
+      expect(registeredTools).toContain('import-markdown');
     });
   });
 });


### PR DESCRIPTION
## Summary

- Fix `create-document`: remove hardcoded `text: 'Test'` default, use empty paragraph
- Fix `duplicate-document`: use `/api/documents/${targetId}?format=json` endpoint to match `create-document` pattern — previously used wrong URL with ID in body
- Fix `import-markdown`: remove dead headers variable, use `buildHeaders` helper
- Add auth comments to `import-markdown` and `export-markdown` explaining `Bearer ${token}` is intentional for the conversion API (different from collaboration API which uses raw token)
- Diversify test tool usage in `mcp-server.test.ts` (previously all used `registerGetServerStatistics` after mechanical replacement)
- Bump version to 1.1.1

## Test plan

- [x] `npm run build` compiles clean
- [x] All 29 unit tests pass
- [x] Smoke tested all tools via MCP against live Tiptap server
- [x] `duplicate-document` now works (was 501 due to wrong endpoint, now creates successfully)

🤖 Generated with [Claude Code](https://claude.com/claude-code)