### PR TITLE
fix: encode URI path params and add passthrough to update/export schemas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tiptap-collaboration-mcp",
-  "version": "1.0.0",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tiptap-collaboration-mcp",
-      "version": "1.0.0",
+      "version": "1.1.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.17.2",
@@ -1821,6 +1821,7 @@
       "integrity": "sha512-DRh5K+ka5eJic8CjH7td8QpYEV6Zo10gfRkjHCO3weqZHWDtAaSTFtl4+VMqOJ4N5jcuhZ9/l+yy8rVgw7BQeQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.10.0"
       }
@@ -2678,6 +2679,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
       "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.0",
@@ -3439,6 +3441,7 @@
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -3452,6 +3455,7 @@
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4616,6 +4620,7 @@
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4716,6 +4721,7 @@
       "integrity": "sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -5007,6 +5013,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tiptap-collaboration-mcp",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "main": "build/index.js",
   "type": "module",
   "scripts": {

--- a/src/server.ts
+++ b/src/server.ts
@@ -16,7 +16,7 @@ let BASE_URL: string | undefined;
 
 const server = new McpServer({
   name: 'tiptap-collaboration-mcp',
-  version: '1.1.1',
+  version: '1.1.2',
   capabilities: {
     resources: {},
     tools: {},

--- a/src/tools/create-document.ts
+++ b/src/tools/create-document.ts
@@ -28,7 +28,7 @@ export default function registerCreateDocument(
         const headers = buildJsonHeaders(getToken());
 
         const response = await fetch(
-          `${getBaseUrl()}/api/documents/${name}?format=json`,
+          `${getBaseUrl()}/api/documents/${encodeURIComponent(name)}?format=json`,
           {
             method: 'POST',
             headers,

--- a/src/tools/delete-document.ts
+++ b/src/tools/delete-document.ts
@@ -18,7 +18,7 @@ export default function registerDeleteDocument(
         const headers = buildHeaders(getToken());
 
         const response = await fetch(
-          `${getBaseUrl()}/api/documents/${id}`,
+          `${getBaseUrl()}/api/documents/${encodeURIComponent(id)}`,
           {
             method: 'DELETE',
             headers,

--- a/src/tools/duplicate-document.ts
+++ b/src/tools/duplicate-document.ts
@@ -19,7 +19,7 @@ export default function registerDuplicateDocument(
     async ({ sourceId, targetId }) => {
       try {
         const getResponse = await fetch(
-          `${getBaseUrl()}/api/documents/${sourceId}`,
+          `${getBaseUrl()}/api/documents/${encodeURIComponent(sourceId)}`,
           { headers: buildHeaders(getToken()) }
         );
 
@@ -37,7 +37,7 @@ export default function registerDuplicateDocument(
         const sourceContent = await getResponse.json();
 
         const createResponse = await fetch(
-          `${getBaseUrl()}/api/documents/${targetId}?format=json`,
+          `${getBaseUrl()}/api/documents/${encodeURIComponent(targetId)}?format=json`,
           {
             method: 'POST',
             headers: buildJsonHeaders(getToken()),

--- a/src/tools/export-markdown.ts
+++ b/src/tools/export-markdown.ts
@@ -13,6 +13,7 @@ export default function registerExportMarkdown(
     {
       content: z
         .object({})
+        .passthrough()
         .describe('Tiptap JSON content to convert to Markdown'),
       format: z
         .enum(['md', 'gfm'])

--- a/src/tools/get-document-statistics.ts
+++ b/src/tools/get-document-statistics.ts
@@ -18,7 +18,7 @@ export default function registerGetDocumentStatistics(
         const headers = buildHeaders(getToken());
 
         const response = await fetch(
-          `${getBaseUrl()}/api/documents/${id}/statistics`,
+          `${getBaseUrl()}/api/documents/${encodeURIComponent(id)}/statistics`,
           { headers }
         );
 

--- a/src/tools/get-document.ts
+++ b/src/tools/get-document.ts
@@ -18,7 +18,7 @@ export default function registerGetDocument(
         const headers = buildHeaders(getToken());
 
         const response = await fetch(
-          `${getBaseUrl()}/api/documents/${id}`,
+          `${getBaseUrl()}/api/documents/${encodeURIComponent(id)}`,
           { headers }
         );
 

--- a/src/tools/update-document.ts
+++ b/src/tools/update-document.ts
@@ -14,6 +14,7 @@ export default function registerUpdateDocument(
       id: z.string().describe('ID of the document to update'),
       content: z
         .object({})
+        .passthrough()
         .describe('Document content in Tiptap JSON format'),
       mode: z
         .enum(['replace', 'append'])
@@ -27,7 +28,7 @@ export default function registerUpdateDocument(
         const headers = buildJsonHeaders(getToken());
 
         const response = await fetch(
-          `${getBaseUrl()}/api/documents/${id}?format=json&mode=${mode}`,
+          `${getBaseUrl()}/api/documents/${encodeURIComponent(id)}?format=json&mode=${mode}`,
           {
             method: 'PATCH',
             headers,

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -77,7 +77,7 @@ describe('MCP Server Integration Tests', () => {
       }).not.toThrow();
     });
 
-    it('should register exactly 12 tools in total', () => {
+    it('should register exactly 11 tools in total', () => {
       registerAll();
       expect(registeredTools).toHaveLength(11);
     });


### PR DESCRIPTION
## Summary
- `update-document` and `export-markdown` content schemas used `z.object({})` without `.passthrough()` — zod was stripping every key from the payload, so updates silently no-oped while returning success. Caught during live smoke test of the deployed MCP against the Tiptap collab container.
- URL-encode all path params (`id`, `name`, `sourceId`, `targetId`) so doc names with `/`, `?`, `#` don't break routing or accidentally hit different endpoints.
- Drive-by: fix stale "12 tools" test description (we have 11) and remove empty `tests/{unit,integration,fixtures,helpers,__mocks__}` scaffolding dirs.

## How the silent update bug surfaced
Smoke-test step 7 (re-fetch after update) returned the pre-update content. Trace: tool handler received `content` but the zod schema stripped it before the fetch, so the body was `{}`. Server accepted, replied 2xx, nothing changed.

## Test plan
- [x] `npm test` — 29 / 29 pass
- [x] `npx tsc -p tsconfig.build.json --noEmit` — clean
- [ ] After redeploy of MCP container, re-run smoke test to confirm step 7 (update verification) now passes
- [ ] Manual check: create a doc named `weird/name?x=1`, verify create/get/delete still target the right doc

## Notes
- No JIRA ticket — found during audit follow-up to PRs #6 and #7
- The bug only affects the deployed MCP build; current production silently drops update payloads